### PR TITLE
add development as default env

### DIFF
--- a/lib/lecca_client/configuration.rb
+++ b/lib/lecca_client/configuration.rb
@@ -10,7 +10,7 @@ module LeccaClient
     end
 
     def environment
-      @environment || ENV['RACK_ENV'] || ENV['RAILS_ENV'] || raise('You must set the environment!')
+      @environment || ENV['RACK_ENV'] || ENV['RAILS_ENV'] || 'development'
     end
 
     def ftp


### PR DESCRIPTION
Add `development` as a default environment, so commands like `rails console` stops to raise exceptions.