### PR TITLE
Remove useless time.zone config

### DIFF
--- a/config/lecca_client.yml
+++ b/config/lecca_client.yml
@@ -16,4 +16,3 @@ test:
     codigo_tabela_juros: 112
     forma_liberacao: 'D'
     forma_liquidacao: 'I'
-  timezone: 'America/Sao_Paulo'

--- a/lib/lecca_client/active_support.rb
+++ b/lib/lecca_client/active_support.rb
@@ -1,5 +1,3 @@
 require 'active_support/inflector/transliterate'
 require 'active_support/core_ext/string'
 require 'active_support/core_ext/time/calculations'
-
-Time.zone ||= LeccaClient.config.timezone

--- a/lib/lecca_client/configuration.rb
+++ b/lib/lecca_client/configuration.rb
@@ -21,10 +21,6 @@ module LeccaClient
       config['proposal']
     end
 
-    def timezone
-      config['timezone']
-    end
-
     private
 
     def config


### PR DESCRIPTION
This config are not being used by the gem and is conflicting with the Rails application, so I'm removing this configuration.