### PR TITLE
fix annoying hashie warning

### DIFF
--- a/lib/lecca_client.rb
+++ b/lib/lecca_client.rb
@@ -6,7 +6,11 @@ module LeccaClient
   end
 end
 
+
 require 'hashie'
+# https://github.com/intridea/hashie/issues/391#issuecomment-276490533
+Hashie.logger = Logger.new(nil)
+
 require 'lecca_client/configuration'
 require 'lecca_client/active_support'
 require 'lecca_client/version'

--- a/lib/lecca_client.rb
+++ b/lib/lecca_client.rb
@@ -6,7 +6,6 @@ module LeccaClient
   end
 end
 
-
 require 'hashie'
 # https://github.com/intridea/hashie/issues/391#issuecomment-276490533
 Hashie.logger = Logger.new(nil)


### PR DESCRIPTION
This PR fixes the annoying hashie warning:
```
WARN -- : You are setting a key that conflicts with a built-in method Hashie::Mash#default defined in Hash. This can cause unexpected behavior when accessing the key via as a property. You can still access the key via the #[] method.
```

It is based on this Issue: https://github.com/intridea/hashie/issues/391#issuecomment-276490533